### PR TITLE
fix consul config key pillar: data_dir

### DIFF
--- a/sls/consul/init.sls
+++ b/sls/consul/init.sls
@@ -2,7 +2,7 @@ include:
   - .pkg
   - .conf
 
-{% set data_dir = salt.pillar.get('consul:main-config:data-dir') %}
+{% set data_dir = salt.pillar.get('consul:main-config:data_dir') %}
 {{ data_dir }}/:
   file.directory:
     - create: True


### PR DESCRIPTION
Fixes `consul[1332680]: * invalid config key data-dir` error